### PR TITLE
Guard EntryType description behind Craft 5.8 version check

### DIFF
--- a/src/tools/CreateEntryType.php
+++ b/src/tools/CreateEntryType.php
@@ -71,7 +71,9 @@ class CreateEntryType
         $entryType = new EntryType();
         $entryType->name = $name;
         $entryType->handle = $handle;
-        $entryType->description = $description;
+        if (version_compare(Craft::$app->getVersion(), '5.8.0', '>=')) {
+            $entryType->description = $description;
+        }
         $entryType->hasTitleField = $hasTitleField;
         $entryType->titleTranslationMethod = $titleTranslationMethodConstant;
         $entryType->titleTranslationKeyFormat = $titleTranslationKeyFormat;
@@ -113,7 +115,7 @@ class CreateEntryType
             'uid' => $savedEntryType->uid,
             'name' => $savedEntryType->name,
             'handle' => $savedEntryType->handle,
-            'description' => $savedEntryType->description,
+            'description' => version_compare(Craft::$app->getVersion(), '5.8.0', '>=') ? $savedEntryType->description : null,
             'hasTitleField' => $savedEntryType->hasTitleField,
             'titleTranslationMethod' => $savedEntryType->titleTranslationMethod,
             'titleTranslationKeyFormat' => $savedEntryType->titleTranslationKeyFormat,

--- a/src/tools/UpdateEntryType.php
+++ b/src/tools/UpdateEntryType.php
@@ -84,7 +84,7 @@ class UpdateEntryType
             $entryType->handle = $handle;
         }
 
-        if ($description !== null) {
+        if ($description !== null && version_compare(Craft::$app->getVersion(), '5.8.0', '>=')) {
             $entryType->description = $description;
         }
 

--- a/stubs/project/project.yaml
+++ b/stubs/project/project.yaml
@@ -127,7 +127,7 @@ plugins:
   commerce:
     edition: pro
     enabled: true
-    schemaVersion: 5.6.0.0
+    schemaVersion: 5.6.1.1
   skills:
     edition: standard
     enabled: true


### PR DESCRIPTION
## Summary
- The `description` property on `EntryType` was added in Craft 5.8.0; assigning it on older 5.x installs throws `UnknownPropertyException`, which broke `entry-types/create` whenever a null description was passed.
- `CreateEntryType` and `UpdateEntryType` now only read/write `description` when `Craft::$app->getVersion()` is `>= 5.8.0`. On older versions the response field falls back to `null`.

## Test plan
- [x] `vendor/bin/pest --filter="CreateEntryType|UpdateEntryType"` (40 passed)
- [ ] Smoke test `entry-types/create` against a Craft 5.7.x install to confirm no UnknownPropertyException
- [ ] Smoke test `entry-types/create` and `entry-types/update` against a Craft 5.8+ install to confirm description still round-trips